### PR TITLE
Use faster method to load entire audio file

### DIFF
--- a/AudioFile.cpp
+++ b/AudioFile.cpp
@@ -24,7 +24,6 @@
 #include <fstream>
 #include <unordered_map>
 #include <iterator>
-#include <sstream>
 
 //=============================================================
 // Pre-defined 10-byte representations of common sample rates
@@ -231,12 +230,13 @@ bool AudioFile<T>::load (std::string filePath)
         return false;
     }
     
-    auto ss = std::ostringstream{};
-    ss << file.rdbuf();
-    auto s = ss.str();
-    std::vector<uint8_t> fileData;
-    std::move( s.begin(), s.end(), std::back_inserter(fileData));
-    
+    auto const start_pos = file.tellg();
+    file.ignore(std::numeric_limits<std::streamsize>::max());
+    auto const char_count = file.gcount();
+    file.seekg(start_pos);
+    auto fileData = std::vector<uint8_t>(char_count);
+    file.read((char*)&fileData[0], fileData.size());
+
     // get audio file format
     audioFileFormat = determineAudioFileFormat (fileData);
     

--- a/AudioFile.cpp
+++ b/AudioFile.cpp
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <unordered_map>
 #include <iterator>
+#include <sstream>
 
 //=============================================================
 // Pre-defined 10-byte representations of common sample rates
@@ -230,9 +231,11 @@ bool AudioFile<T>::load (std::string filePath)
         return false;
     }
     
-    file.unsetf (std::ios::skipws);
-    std::istream_iterator<uint8_t> begin (file), end;
-    std::vector<uint8_t> fileData (begin, end);
+    auto ss = std::ostringstream{};
+    ss << file.rdbuf();
+    auto s = ss.str();
+    std::vector<uint8_t> fileData;
+    std::move( s.begin(), s.end(), std::back_inserter(fileData));
     
     // get audio file format
     audioFileFormat = determineAudioFileFormat (fileData);


### PR DESCRIPTION
Used the method from http://cpp.indi.frih.net/blog/2014/09/how-to-read-an-entire-file-into-memory-in-cpp/ to improve reading speed. In my profiling, I found a collection of wave files took ~3 seconds to load with the original method, and this improvement brought it down to ~1 second. 

I verified all the reading and writing Unit Tests passed as well. 