### PR TITLE
Support wstring

### DIFF
--- a/AudioFile.h
+++ b/AudioFile.h
@@ -63,11 +63,26 @@ public:
      * @Returns true if the file was successfully loaded
      */
     bool load (std::string filePath);
+
+#if defined(_MSC_VER)
+    //=============================================================
+    /** Loads an audio file from a given file path.
+     * @Returns true if the file was successfully loaded
+     */
+    bool load (std::wstring filePath);
+#endif
     
     /** Saves an audio file to a given file path.
      * @Returns true if the file was successfully saved
      */
     bool save (std::string filePath, AudioFileFormat format = AudioFileFormat::Wave);
+
+#if defined(_MSC_VER)
+    /** Saves an audio file to a given file path.
+     * @Returns true if the file was successfully saved
+     */
+    bool save (std::wstring filePath, AudioFileFormat format = AudioFileFormat::Wave);
+#endif
         
     //=============================================================
     /** @Returns the sample rate */
@@ -138,13 +153,21 @@ private:
     };
     
     //=============================================================
+    template <class StringType>
+    bool loadImpl (StringType filePath);
+    template <class StringType>
+    bool saveImpl (StringType filePath, AudioFileFormat format);
+
+    //=============================================================
     AudioFileFormat determineAudioFileFormat (std::vector<uint8_t>& fileData);
     bool decodeWaveFile (std::vector<uint8_t>& fileData);
     bool decodeAiffFile (std::vector<uint8_t>& fileData);
     
     //=============================================================
-    bool saveToWaveFile (std::string filePath);
-    bool saveToAiffFile (std::string filePath);
+    template <class StringType>
+    bool saveToWaveFile (StringType filePath);
+    template <class StringType>
+    bool saveToAiffFile (StringType filePath);
     
     //=============================================================
     void clearAudioBuffer();
@@ -173,7 +196,8 @@ private:
     void addInt16ToFileData (std::vector<uint8_t>& fileData, int16_t i, Endianness endianness = Endianness::LittleEndian);
     
     //=============================================================
-    bool writeDataToFile (std::vector<uint8_t>& fileData, std::string filePath);
+    template <class StringType>
+    bool writeDataToFile (std::vector<uint8_t>& fileData, StringType filePath);
     
     //=============================================================
     AudioFileFormat audioFileFormat;
@@ -380,6 +404,23 @@ void AudioFile<T>::setSampleRate (uint32_t newSampleRate)
 //=============================================================
 template <class T>
 bool AudioFile<T>::load (std::string filePath)
+{
+    return loadImpl(filePath);
+}
+
+//=============================================================
+#if defined(_MSC_VER)
+template <class T>
+bool AudioFile<T>::load (std::wstring filePath)
+{
+    return loadImpl(filePath);
+}
+#endif
+
+//=============================================================
+template <class T>
+template <class StringType>
+bool AudioFile<T>::loadImpl (StringType filePath)
 {
     std::ifstream file (filePath, std::ios::binary);
     
@@ -685,6 +726,23 @@ void AudioFile<T>::addSampleRateToAiffData (std::vector<uint8_t>& fileData, uint
 template <class T>
 bool AudioFile<T>::save (std::string filePath, AudioFileFormat format)
 {
+    return saveImpl(filePath, format);
+}
+
+#if defined(_MSC_VER)
+//=============================================================
+template <class T>
+bool AudioFile<T>::save (std::wstring filePath, AudioFileFormat format)
+{
+    return saveImpl(filePath, format);
+}
+#endif
+
+//=============================================================
+template <class T>
+template <class StringType>
+bool AudioFile<T>::saveImpl (StringType filePath, AudioFileFormat format)
+{
     if (format == AudioFileFormat::Wave)
     {
         return saveToWaveFile (filePath);
@@ -699,7 +757,8 @@ bool AudioFile<T>::save (std::string filePath, AudioFileFormat format)
 
 //=============================================================
 template <class T>
-bool AudioFile<T>::saveToWaveFile (std::string filePath)
+template <class StringType>
+bool AudioFile<T>::saveToWaveFile (StringType filePath)
 {
     std::vector<uint8_t> fileData;
     
@@ -785,7 +844,8 @@ bool AudioFile<T>::saveToWaveFile (std::string filePath)
 
 //=============================================================
 template <class T>
-bool AudioFile<T>::saveToAiffFile (std::string filePath)
+template <class StringType>
+bool AudioFile<T>::saveToAiffFile (StringType filePath)
 {
     std::vector<uint8_t> fileData;
     
@@ -869,7 +929,8 @@ bool AudioFile<T>::saveToAiffFile (std::string filePath)
 
 //=============================================================
 template <class T>
-bool AudioFile<T>::writeDataToFile (std::vector<uint8_t>& fileData, std::string filePath)
+template <class StringType>
+bool AudioFile<T>::writeDataToFile (std::vector<uint8_t>& fileData, StringType filePath)
 {
     std::ofstream outputFile (filePath, std::ios::binary);
     

--- a/AudioFile.h
+++ b/AudioFile.h
@@ -198,6 +198,12 @@ private:
     //=============================================================
     template <class StringType>
     bool writeDataToFile (std::vector<uint8_t>& fileData, StringType filePath);
+
+    //=============================================================
+    void showFileLoadError (std::string filePath);
+    void showFileLoadError (std::wstring filePath);
+    void showFileSaveError (std::string filePath);
+    void showFileSaveError (std::wstring filePath);
     
     //=============================================================
     AudioFileFormat audioFileFormat;
@@ -427,8 +433,7 @@ bool AudioFile<T>::loadImpl (StringType filePath)
     // check the file exists
     if (! file.good())
     {
-        std::cout << "ERROR: File doesn't exist or otherwise can't load file" << std::endl;
-        std::cout << filePath << std::endl;
+        showFileLoadError(filePath);
         return false;
     }
     
@@ -834,7 +839,7 @@ bool AudioFile<T>::saveToWaveFile (StringType filePath)
     // check that the various sizes we put in the metadata are correct
     if (fileSizeInBytes != (fileData.size() - 8) || dataChunkSize != (getNumSamplesPerChannel() * getNumChannels() * (bitDepth / 8)))
     {
-        std::cout << "ERROR: couldn't save file to " << filePath << std::endl;
+        showFileSaveError(filePath);
         return false;
     }
     
@@ -919,7 +924,7 @@ bool AudioFile<T>::saveToAiffFile (StringType filePath)
     // check that the various sizes we put in the metadata are correct
     if (fileSizeInBytes != (fileData.size() - 8) || soundDataChunkSize != getNumSamplesPerChannel() *  numBytesPerFrame + 8)
     {
-        std::cout << "ERROR: couldn't save file to " << filePath << std::endl;
+        showFileSaveError(filePath);
         return false;
     }
     
@@ -948,6 +953,36 @@ bool AudioFile<T>::writeDataToFile (std::vector<uint8_t>& fileData, StringType f
     }
     
     return false;
+}
+
+//=============================================================
+template <class T>
+void AudioFile<T>::showFileLoadError (std::string filePath)
+{
+    std::cout << "ERROR: File doesn't exist or otherwise can't load file" << std::endl;
+    std::cout << filePath << std::endl;
+}
+
+//=============================================================
+template <class T>
+void AudioFile<T>::showFileLoadError (std::wstring filePath)
+{
+    std::wcout << L"ERROR: File doesn't exist or otherwise can't load file" << std::endl;
+    std::wcout << filePath << std::endl;
+}
+
+//=============================================================
+template <class T>
+void AudioFile<T>::showFileSaveError (std::string filePath)
+{
+    std::cout << "ERROR: couldn't save file to " << filePath << std::endl;
+}
+
+//=============================================================
+template <class T>
+void AudioFile<T>::showFileSaveError (std::wstring filePath)
+{
+    std::wcout << L"ERROR: couldn't save file to " << filePath << std::endl;
 }
 
 //=============================================================


### PR DESCRIPTION
Enable AudioFile class to open files of which filename contains unicode characters.

On windows platform, the standard file streams can't open files with std::string if the filename of the file contains unicode characters.

Visual Studio STL has overloads which takes std::wstring for standard file streams to open such files. 

```cpp
std::string path = "😀😁😂.txt";
std::wstring wpath = L"😀😁😂.txt";

std::ofstream ofs1(path);  // NG.
std::ofstream ofs2(wpath); // OK.
```