### PR TITLE
Fixing my bug - AIFF chunk sizes are big endian.

### DIFF
--- a/AudioFile.h
+++ b/AudioFile.h
@@ -1003,7 +1003,7 @@ bool AudioFile<T>::saveToAiffFile (std::string filePath)
     if (iXMLChunkSize > 0)
     {
         addStringToFileData (fileData, "iXML");
-        addInt32ToFileData (fileData, iXMLChunkSize);
+        addInt32ToFileData (fileData, iXMLChunkSize, Endianness::BigEndian);
         addStringToFileData (fileData, iXMLChunk);
     }
     


### PR DESCRIPTION
@adamstark sorry about this - I caught it when trying to generate some AIFF files with iXML for use elsewhere. 