### PR TITLE
fix build on WSL Ubuntu 20.04 GCC

### DIFF
--- a/AudioFile.h
+++ b/AudioFile.h
@@ -25,8 +25,9 @@
 
 #include <iostream>
 #include <vector>
-#include <assert.h>
+#include <cassert>
 #include <string>
+#include <cstring>
 #include <fstream>
 #include <unordered_map>
 #include <iterator>


### PR DESCRIPTION
I had a compile error due to `memcmp` not being declared in the scope.
OS: WSL Ubuntu 20.04 (hosted on Windows 10 Build 20190.rs_prerelease.200807-1609)
Compiler: GCC 9.3.0
error: `memcmp` was not declared in this scope

let me know if you need any more information on my build environment.

Hopefully, this bug can be replicated. These changes fixed the build on my repo and so I wanted to make sure others didn't have the same problem.

list of changes:
added \<cstring\> header to include memcmp
*not a bug* additionally changed \<assert.h\> to the slightly more c++ esque modern \<cassert\>