### PR TITLE
Add cstring include

### DIFF
--- a/AudioFile.h
+++ b/AudioFile.h
@@ -31,6 +31,7 @@
 #include <unordered_map>
 #include <iterator>
 #include <algorithm>
+#include <cstring>
 
 // disable some warnings on Windows
 #if defined (_MSC_VER)


### PR DESCRIPTION
First of all, thanks for the useful code!

When I was including the header to my code, I was getting the "there are no arguments to memcmp that depend on a template parameter, so a declaration of memcmp must be available" error. 
By using the -fpermissive flag, this turns to a warning, but it was still kind of annoying, therefore I included 'cstring' to your code so as to make the error/warning disappear completely. Though I should share in case you want this in the master branch.

P.S. I am using the C++ GNU compiler with the -std=gnu++11 flag.