### PR TITLE
Separate wave header decoding

### DIFF
--- a/AudioFile.h
+++ b/AudioFile.h
@@ -201,7 +201,6 @@ private:
     //=============================================================
     AudioFileFormat determineAudioFileFormat (std::vector<uint8_t>& fileData);
     bool decodeWaveFile (std::vector<uint8_t>& fileData);
-    bool decodeWaveFile (std::vector<uint8_t>& fileData, WaveHeader header);
     bool decodeWaveHeader (std::vector<uint8_t>& fileData, WaveHeader& output);
     //=============================================================
 
@@ -555,13 +554,7 @@ bool AudioFile<T>::decodeWaveFile (std::vector<uint8_t>& fileData)
     if (!decodeWaveHeader(fileData, header)){
         return false;
     }
-    return decodeWaveFile(fileData, header);
-}
 
-//=============================================================
-template <class T>
-bool AudioFile<T>::decodeWaveFile (std::vector<uint8_t>& fileData, WaveHeader header)
-{
     int numSamples = header.dataChunkSize / (header.numChannels * header.bitDepth / 8);
     int indexOfDataChunk = getIndexOfChunk (fileData, "data", 12);
     int samplesStartIndex = indexOfDataChunk + 8;

--- a/AudioFile.h
+++ b/AudioFile.h
@@ -500,14 +500,7 @@ bool AudioFile<T>::load ()
 template <class T>
 bool AudioFile<T>::load (std::string filePathParam)
 {
-    if (filePath != "")
-    {
-        reportError ("ERROR: Trying to load path with explicit file path (" + filePathParam + "), while one was already set, using original (" + filePath + ")");
-    } 
-    else 
-    {
-        filePath = filePathParam;
-    }
+    filePath = filePathParam;
 
     std::ifstream file (filePath, std::ios::binary);
     

--- a/tests/WavLoadingTests.cpp
+++ b/tests/WavLoadingTests.cpp
@@ -265,6 +265,20 @@ TEST_SUITE ("WavLoadingTests")
         }
     }
 
+    TEST_CASE ("WavLoadingTests_Mono_16bit_48000_extract_header")
+    {
+        AudioFile<double> audioFile(projectBuildDirectory + "/test-audio/wav_mono_16bit_48000.wav", false);
+        WaveHeader header;
+        bool loadedOK = audioFile.extractWaveHeader(header);
+
+        CHECK (loadedOK);
+        
+        CHECK_EQ (header.headerChunkID, "RIFF");
+        CHECK_EQ (header.formatChunkID, "fmt ");
+        CHECK_EQ (header.numChannels, wav_mono_16bit_48000::numChannels);
+        CHECK_EQ (header.sampleRate, wav_mono_16bit_48000::sampleRate);
+    }
+
     //=============================================================
     TEST_CASE ("WavLoadingTests_Mono_24bit_48000")
     {


### PR DESCRIPTION
Hey, i wanted to obtain some wave file metadata, so i refactored the loading process to allow loading of only the header.
This could also be used to implement a partial load in the future. 

I didn't implement it for AIFF files (yet) because i don't know if its possible in the same way. I never worked with that format before. It didn't seem a big problem because the loading of different file types is pretty isolated.