### PR TITLE
Fix type punning

### DIFF
--- a/AudioFile.h
+++ b/AudioFile.h
@@ -638,13 +638,16 @@ bool AudioFile<T>::decodeWaveFile (std::vector<uint8_t>& fileData)
             {
                 int32_t sampleAsInt = fourBytesToInt (fileData, sampleIndex);
                 T sample;
-                if (audioFormat == WavAudioFormat::IEEEFloat) {
+                if (audioFormat == WavAudioFormat::IEEEFloat) 
+		{
                     float f;
                     memcpy(&f, &sampleAsInt, sizeof(int32_t));
                     sample = (T)f;
                 }
                 else // assume PCM
+		{
                     sample = (T) sampleAsInt / static_cast<float> (std::numeric_limits<std::int32_t>::max());
+		}
                 
                 samples[channel].push_back (sample);
             }
@@ -785,13 +788,16 @@ bool AudioFile<T>::decodeAiffFile (std::vector<uint8_t>& fileData)
             {
                 int32_t sampleAsInt = fourBytesToInt (fileData, sampleIndex, Endianness::BigEndian);
                 T sample;
-                if (audioFormat == AIFFAudioFormat::Compressed) {
+                if (audioFormat == AIFFAudioFormat::Compressed) 
+		{
                     float f;
                     memcpy(&f, &sampleAsInt, sizeof(int32_t));
                     sample = (T)f;
                 }
                 else // assume uncompressed
+		{
                     sample = (T) sampleAsInt / static_cast<float> (std::numeric_limits<std::int32_t>::max());
+		}
                     
                 samples[channel].push_back (sample);
             }

--- a/AudioFile.h
+++ b/AudioFile.h
@@ -638,9 +638,11 @@ bool AudioFile<T>::decodeWaveFile (std::vector<uint8_t>& fileData)
             {
                 int32_t sampleAsInt = fourBytesToInt (fileData, sampleIndex);
                 T sample;
-                
-                if (audioFormat == WavAudioFormat::IEEEFloat)
-                    sample = (T)reinterpret_cast<float&> (sampleAsInt);
+                if (audioFormat == WavAudioFormat::IEEEFloat) {
+                    float f;
+                    memcpy(&f, &sampleAsInt, sizeof(int32_t));
+                    sample = (T)f;
+                }
                 else // assume PCM
                     sample = (T) sampleAsInt / static_cast<float> (std::numeric_limits<std::int32_t>::max());
                 
@@ -783,9 +785,11 @@ bool AudioFile<T>::decodeAiffFile (std::vector<uint8_t>& fileData)
             {
                 int32_t sampleAsInt = fourBytesToInt (fileData, sampleIndex, Endianness::BigEndian);
                 T sample;
-                
-                if (audioFormat == AIFFAudioFormat::Compressed)
-                    sample = (T)reinterpret_cast<float&> (sampleAsInt);
+                if (audioFormat == AIFFAudioFormat::Compressed) {
+                    float f;
+                    memcpy(&f, &sampleAsInt, sizeof(int32_t));
+                    sample = (T)f;
+                }
                 else // assume uncompressed
                     sample = (T) sampleAsInt / static_cast<float> (std::numeric_limits<std::int32_t>::max());
                     


### PR DESCRIPTION
### Description

When compiling with `-Werror=strict-aliasing`, Audiofile fails to compile due to [type punning](https://en.wikipedia.org/wiki/Type_punning). This change works around that with a simple memcpy trick - not the most elegant but effective. The test passes locally on my system after this change (`make test`).