### PR TITLE
Add check to validate chunk size

### DIFF
--- a/AudioFile.h
+++ b/AudioFile.h
@@ -1318,7 +1318,13 @@ int AudioFile<T>::getIndexOfChunk (std::vector<uint8_t>& source, const std::stri
         if ((i + 4) >= source.size())
             return -1;
         
-        auto chunkSize = fourBytesToInt (source, i, endianness);
+        uint32_t chunkSize = fourBytesToInt (source, i, endianness);
+        // Assume chunk size is invalid if it's greater than the number of bytes remaining in source
+        if (chunkSize > (source.size() - i - dataLen))
+        {
+            assert (false && "Invalid chunk size");
+            return -1;
+        }
         i += (dataLen + chunkSize);
     }
 

--- a/AudioFile.h
+++ b/AudioFile.h
@@ -1318,9 +1318,9 @@ int AudioFile<T>::getIndexOfChunk (std::vector<uint8_t>& source, const std::stri
         if ((i + 4) >= source.size())
             return -1;
         
-        uint32_t chunkSize = fourBytesToInt (source, i, endianness);
+        int32_t chunkSize = fourBytesToInt (source, i, endianness);
         // Assume chunk size is invalid if it's greater than the number of bytes remaining in source
-        if (chunkSize > (source.size() - i - dataLen))
+        if (chunkSize > (source.size() - i - dataLen) || (chunkSize < 0))
         {
             assert (false && "Invalid chunk size");
             return -1;


### PR DESCRIPTION
The chunk size read from the file in `getIndexOfChunk()` is not currently checked for correctness - an infinite loop can be triggered by setting it to -8 (example attached).
[negative_chunk_size.zip](https://github.com/adamstark/AudioFile/files/10952230/negative_chunk_size.zip)
