### PR TITLE
Replace cout with cerr for info/error reporting

### DIFF
--- a/AudioFile.h
+++ b/AudioFile.h
@@ -357,13 +357,13 @@ double AudioFile<T>::getLengthInSeconds() const
 template <class T>
 void AudioFile<T>::printSummary() const
 {
-    std::cout << "|======================================|" << std::endl;
-    std::cout << "Num Channels: " << getNumChannels() << std::endl;
-    std::cout << "Num Samples Per Channel: " << getNumSamplesPerChannel() << std::endl;
-    std::cout << "Sample Rate: " << sampleRate << std::endl;
-    std::cout << "Bit Depth: " << bitDepth << std::endl;
-    std::cout << "Length in Seconds: " << getLengthInSeconds() << std::endl;
-    std::cout << "|======================================|" << std::endl;
+    std::cerr << "|======================================|" << std::endl;
+    std::cerr << "Num Channels: " << getNumChannels() << std::endl;
+    std::cerr << "Num Samples Per Channel: " << getNumSamplesPerChannel() << std::endl;
+    std::cerr << "Sample Rate: " << sampleRate << std::endl;
+    std::cerr << "Bit Depth: " << bitDepth << std::endl;
+    std::cerr << "Length in Seconds: " << getLengthInSeconds() << std::endl;
+    std::cerr << "|======================================|" << std::endl;
 }
 
 //=============================================================
@@ -1307,7 +1307,7 @@ template <class T>
 void AudioFile<T>::reportError (std::string errorMessage)
 {
     if (logErrorsToConsole)
-        std::cout << errorMessage << std::endl;
+        std::cerr << errorMessage << std::endl;
 }
 
 #if defined (_MSC_VER)


### PR DESCRIPTION
This change simply replaces all instances of `std::cout` with `std::cerr` in `AudioFile.h`.

It is considered standard to use `stderr` instead of `stdout` for reporting errors and info, because `stdout` should be reserved for program output that could be redirected into another program as input. For instance if you are using AudioFile to develop a command-line utility, that utility may be using `stdout` for its actual output; you'd expect any error messages to be printed to `stderr` so that they still get printed to to the terminal even if output is directed elsewhere, and so that those error messages / reports don't make it into the output of the utility.

This will also make it so that developers using `AudioFile.h` do not have to suppress errors just to prevent AudioFile from interfering with their program's output; now, a developer would only turn off error logging if they actually did not want to see them or for some other reason did not want them printed to the console at all. This is the situation in which one would expect a developer to turn off errors in the first place.