### PR TITLE
Remove the NOMINMAX definition

### DIFF
--- a/AudioFile.h
+++ b/AudioFile.h
@@ -31,12 +31,6 @@
 #ifndef _AS_AudioFile_h
 #define _AS_AudioFile_h
 
-#if defined (_MSC_VER)
-#undef max
-#undef min
-#define NOMINMAX
-#endif
-
 #include <iostream>
 #include <vector>
 #include <cassert>
@@ -1343,7 +1337,7 @@ typename std::make_unsigned<SignedType>::type convertSignedToUnsigned (SignedTyp
 {
     static_assert (std::is_signed<SignedType>::value, "The input value must be signed");
     
-    typename std::make_unsigned<SignedType>::type unsignedValue = static_cast<typename std::make_unsigned<SignedType>::type> (1) + std::numeric_limits<SignedType>::max();
+    typename std::make_unsigned<SignedType>::type unsignedValue = static_cast<typename std::make_unsigned<SignedType>::type> (1) + (std::numeric_limits<SignedType>::max)();
     
     unsignedValue += signedValue;
     return unsignedValue;
@@ -1368,7 +1362,7 @@ T AudioSampleConverter<T>::thirtyTwoBitIntToSample (int32_t sample)
 {
     if constexpr (std::is_floating_point<T>::value)
     {
-        return static_cast<T> (sample) / static_cast<T> (std::numeric_limits<int32_t>::max());
+        return static_cast<T> (sample) / static_cast<T> ((std::numeric_limits<int32_t>::max)());
     }
     else if (std::numeric_limits<T>::is_integer)
     {
@@ -1391,15 +1385,15 @@ int32_t AudioSampleConverter<T>::sampleToThirtyTwoBitInt (T sample)
         if constexpr (std::is_same_v<T, float>)
         {
             if (sample >= 1.f)
-                return std::numeric_limits<int32_t>::max();
+                return (std::numeric_limits<int32_t>::max)();
             else if (sample <= -1.f)
                 return std::numeric_limits<int32_t>::lowest() + 1; // starting at 1 preserves symmetry
             else
-                return static_cast<int32_t> (sample * std::numeric_limits<int32_t>::max());
+                return static_cast<int32_t> (sample * (std::numeric_limits<int32_t>::max)());
         }
         else
         {
-            return static_cast<int32_t> (clamp (sample, -1., 1.) * std::numeric_limits<int32_t>::max());
+            return static_cast<int32_t> (clamp (sample, -1., 1.) * (std::numeric_limits<int32_t>::max)());
         }
     }
     else
@@ -1556,8 +1550,8 @@ T AudioSampleConverter<T>::signedByteToSample (int8_t sample)
 template <class T>
 T AudioSampleConverter<T>::clamp (T value, T minValue, T maxValue)
 {
-    value = std::min (value, maxValue);
-    value = std::max (value, minValue);
+    value = (std::min) (value, maxValue);
+    value = (std::max) (value, minValue);
     return value;
 }
 

--- a/tests/GeneralTests.cpp
+++ b/tests/GeneralTests.cpp
@@ -20,7 +20,7 @@ TEST_SUITE ("General Tests")
         CHECK (a.getNumSamplesPerChannel() == b.getNumSamplesPerChannel());
         CHECK (a.getLengthInSeconds() == b.getLengthInSeconds());
         
-        size_t numSamplesToTest = std::min (static_cast<size_t> (20000), a.samples[0].size());
+        size_t numSamplesToTest = (std::min) (static_cast<size_t> (20000), a.samples[0].size());
         
         for (size_t channel = 0; channel < a.samples.size(); channel++)
         {

--- a/tests/SampleConversionTests.cpp
+++ b/tests/SampleConversionTests.cpp
@@ -95,7 +95,7 @@ TEST_SUITE ("SampleConversionTests::8-bit Conversions - sampleToSignedByte()")
     //=============================================================
     TEST_CASE ("8-bit Signed Conversions::sampleToSignedByte (float and double)")
     {
-        REQUIRE_EQ (AudioSampleConverter<float>::sampleToSignedByte (std::numeric_limits<float>::max()), 127);
+        REQUIRE_EQ (AudioSampleConverter<float>::sampleToSignedByte ((std::numeric_limits<float>::max)()), 127);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToSignedByte (1.f), 127);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToSignedByte (0.5f), 63);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToSignedByte (0.f), 0);
@@ -103,7 +103,7 @@ TEST_SUITE ("SampleConversionTests::8-bit Conversions - sampleToSignedByte()")
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToSignedByte (-1.f), -127);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToSignedByte (std::numeric_limits<float>::lowest()), -127);
         
-        REQUIRE_EQ (AudioSampleConverter<double>::sampleToSignedByte (std::numeric_limits<float>::max()), 127);
+        REQUIRE_EQ (AudioSampleConverter<double>::sampleToSignedByte ((std::numeric_limits<float>::max)()), 127);
         REQUIRE_EQ (AudioSampleConverter<double>::sampleToSignedByte (1.), 127);
         REQUIRE_EQ (AudioSampleConverter<double>::sampleToSignedByte (0.5), 63);
         REQUIRE_EQ (AudioSampleConverter<double>::sampleToSignedByte (0.), 0);
@@ -122,32 +122,32 @@ TEST_SUITE ("SampleConversionTests::8-bit Conversions - sampleToSignedByte()")
         REQUIRE_EQ (AudioSampleConverter<uint8_t>::sampleToSignedByte (1), -127);
         REQUIRE_EQ (AudioSampleConverter<uint8_t>::sampleToSignedByte (0), -128);
         
-        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSignedByte (std::numeric_limits<uint16_t>::max()), 127);
+        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSignedByte ((std::numeric_limits<uint16_t>::max)()), 127);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSignedByte (255), 127);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSignedByte (191), 63);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSignedByte (128), 0);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSignedByte (65), -63);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSignedByte (1), -127);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSignedByte (0), -128);
-        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSignedByte (std::numeric_limits<uint16_t>::min()), -128);
+        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSignedByte ((std::numeric_limits<uint16_t>::min)()), -128);
         
-        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSignedByte (std::numeric_limits<uint32_t>::max()), 127);
+        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSignedByte ((std::numeric_limits<uint32_t>::max)()), 127);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSignedByte (255), 127);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSignedByte (191), 63);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSignedByte (128), 0);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSignedByte (65), -63);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSignedByte (1), -127);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSignedByte (0), -128);
-        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSignedByte (std::numeric_limits<uint32_t>::min()), -128);
+        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSignedByte ((std::numeric_limits<uint32_t>::min)()), -128);
         
-        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSignedByte (std::numeric_limits<uint64_t>::max()), 127);
+        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSignedByte ((std::numeric_limits<uint64_t>::max)()), 127);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSignedByte (255), 127);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSignedByte (191), 63);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSignedByte (128), 0);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSignedByte (65), -63);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSignedByte (1), -127);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSignedByte (0), -128);
-        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSignedByte (std::numeric_limits<uint64_t>::min()), -128);
+        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSignedByte ((std::numeric_limits<uint64_t>::min)()), -128);
     }
     
     //=============================================================
@@ -160,32 +160,32 @@ TEST_SUITE ("SampleConversionTests::8-bit Conversions - sampleToSignedByte()")
         REQUIRE_EQ (AudioSampleConverter<int8_t>::sampleToSignedByte (-127), -127);
         REQUIRE_EQ (AudioSampleConverter<int8_t>::sampleToSignedByte (-128), -128);
         
-        REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSignedByte (std::numeric_limits<int16_t>::max()), 127);
+        REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSignedByte ((std::numeric_limits<int16_t>::max)()), 127);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSignedByte (127), 127);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSignedByte (63), 63);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSignedByte (0), 0);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSignedByte (-63), -63);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSignedByte (-127), -127);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSignedByte (-128), -128);
-        REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSignedByte (std::numeric_limits<int16_t>::min()), -128);
+        REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSignedByte ((std::numeric_limits<int16_t>::min)()), -128);
         
-        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSignedByte (std::numeric_limits<int32_t>::max()), 127);
+        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSignedByte ((std::numeric_limits<int32_t>::max)()), 127);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSignedByte (127), 127);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSignedByte (63), 63);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSignedByte (0), 0);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSignedByte (-63), -63);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSignedByte (-127), -127);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSignedByte (-128), -128);
-        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSignedByte (std::numeric_limits<int32_t>::min()), -128);
+        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSignedByte ((std::numeric_limits<int32_t>::min)()), -128);
         
-        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSignedByte (std::numeric_limits<int64_t>::max()), 127);
+        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSignedByte ((std::numeric_limits<int64_t>::max)()), 127);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSignedByte (127), 127);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSignedByte (63), 63);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSignedByte (0), 0);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSignedByte (-63), -63);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSignedByte (-127), -127);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSignedByte (-128), -128);
-        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSignedByte (std::numeric_limits<int64_t>::min()), -128);
+        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSignedByte ((std::numeric_limits<int64_t>::min)()), -128);
     }
 }
  
@@ -281,7 +281,7 @@ TEST_SUITE ("SampleConversionTests::8-bit Conversions - sampleToUnsignedByte()")
     //=============================================================
     TEST_CASE ("8-bit Signed Conversions::sampleToUnsignedByte (float and double)")
     {
-        REQUIRE_EQ (AudioSampleConverter<float>::sampleToUnsignedByte (std::numeric_limits<float>::max()), 255);
+        REQUIRE_EQ (AudioSampleConverter<float>::sampleToUnsignedByte ((std::numeric_limits<float>::max)()), 255);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToUnsignedByte (1.f), 255);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToUnsignedByte (0.5f), 191);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToUnsignedByte (0.f), 128);
@@ -289,7 +289,7 @@ TEST_SUITE ("SampleConversionTests::8-bit Conversions - sampleToUnsignedByte()")
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToUnsignedByte (-1.f), 1);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToUnsignedByte (std::numeric_limits<float>::lowest()), 1);
         
-        REQUIRE_EQ (AudioSampleConverter<double>::sampleToUnsignedByte (std::numeric_limits<double>::max()), 255);
+        REQUIRE_EQ (AudioSampleConverter<double>::sampleToUnsignedByte ((std::numeric_limits<double>::max)()), 255);
         REQUIRE_EQ (AudioSampleConverter<double>::sampleToUnsignedByte (1.), 255);
         REQUIRE_EQ (AudioSampleConverter<double>::sampleToUnsignedByte (0.5), 191);
         REQUIRE_EQ (AudioSampleConverter<double>::sampleToUnsignedByte (0.), 128);
@@ -308,32 +308,32 @@ TEST_SUITE ("SampleConversionTests::8-bit Conversions - sampleToUnsignedByte()")
         REQUIRE_EQ (AudioSampleConverter<uint8_t>::sampleToUnsignedByte (1), 1);
         REQUIRE_EQ (AudioSampleConverter<uint8_t>::sampleToUnsignedByte (0), 0);
         
-        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToUnsignedByte (std::numeric_limits<uint16_t>::max()), 255);
+        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToUnsignedByte ((std::numeric_limits<uint16_t>::max)()), 255);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToUnsignedByte (255), 255);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToUnsignedByte (191), 191);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToUnsignedByte (128), 128);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToUnsignedByte (65), 65);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToUnsignedByte (1), 1);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToUnsignedByte (0), 0);
-        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToUnsignedByte (std::numeric_limits<uint16_t>::min()), 0);
+        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToUnsignedByte ((std::numeric_limits<uint16_t>::min)()), 0);
         
-        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToUnsignedByte (std::numeric_limits<uint32_t>::max()), 255);
+        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToUnsignedByte ((std::numeric_limits<uint32_t>::max)()), 255);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToUnsignedByte (255), 255);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToUnsignedByte (191), 191);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToUnsignedByte (128), 128);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToUnsignedByte (65), 65);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToUnsignedByte (1), 1);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToUnsignedByte (0), 0);
-        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToUnsignedByte (std::numeric_limits<uint32_t>::min()), 0);
+        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToUnsignedByte ((std::numeric_limits<uint32_t>::min)()), 0);
         
-        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToUnsignedByte (std::numeric_limits<uint64_t>::max()), 255);
+        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToUnsignedByte ((std::numeric_limits<uint64_t>::max)()), 255);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToUnsignedByte (255), 255);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToUnsignedByte (191), 191);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToUnsignedByte (128), 128);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToUnsignedByte (65), 65);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToUnsignedByte (1), 1);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToUnsignedByte (0), 0);
-        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToUnsignedByte (std::numeric_limits<uint64_t>::min()), 0);
+        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToUnsignedByte ((std::numeric_limits<uint64_t>::min)()), 0);
     }
     
     //=============================================================
@@ -346,32 +346,32 @@ TEST_SUITE ("SampleConversionTests::8-bit Conversions - sampleToUnsignedByte()")
         REQUIRE_EQ (AudioSampleConverter<int8_t>::sampleToUnsignedByte (-127), 1);
         REQUIRE_EQ (AudioSampleConverter<int8_t>::sampleToUnsignedByte (-128), 0);
         
-        REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToUnsignedByte (std::numeric_limits<int16_t>::max()), 255);
+        REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToUnsignedByte ((std::numeric_limits<int16_t>::max)()), 255);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToUnsignedByte (127), 255);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToUnsignedByte (63), 191);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToUnsignedByte (0), 128);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToUnsignedByte (-63), 65);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToUnsignedByte (-127), 1);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToUnsignedByte (-128), 0);
-        REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToUnsignedByte (std::numeric_limits<int16_t>::min()), 0);
+        REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToUnsignedByte ((std::numeric_limits<int16_t>::min)()), 0);
         
-        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToUnsignedByte (std::numeric_limits<int32_t>::max()), 255);
+        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToUnsignedByte ((std::numeric_limits<int32_t>::max)()), 255);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToUnsignedByte (127), 255);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToUnsignedByte (63), 191);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToUnsignedByte (0), 128);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToUnsignedByte (-63), 65);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToUnsignedByte (-127), 1);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToUnsignedByte (-128), 0);
-        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToUnsignedByte (std::numeric_limits<int32_t>::min()), 0);
+        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToUnsignedByte ((std::numeric_limits<int32_t>::min)()), 0);
         
-        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToUnsignedByte (std::numeric_limits<int64_t>::max()), 255);
+        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToUnsignedByte ((std::numeric_limits<int64_t>::max)()), 255);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToUnsignedByte (127), 255);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToUnsignedByte (63), 191);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToUnsignedByte (0), 128);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToUnsignedByte (-63), 65);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToUnsignedByte (-127), 1);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToUnsignedByte (-128), 0);
-        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToUnsignedByte (std::numeric_limits<int64_t>::min()), 0);
+        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToUnsignedByte ((std::numeric_limits<int64_t>::min)()), 0);
     }
 }
 
@@ -470,38 +470,38 @@ TEST_SUITE ("SampleConversionTests::16-bit Conversions")
     //=============================================================
     TEST_CASE ("16-bit Conversions::sampleToSixteenBitInt (unsigned int)")
     {
-        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSixteenBitInt (std::numeric_limits<uint16_t>::max()), 32767);
+        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSixteenBitInt ((std::numeric_limits<uint16_t>::max)()), 32767);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSixteenBitInt (65535), 32767);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSixteenBitInt (49151), 16383);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSixteenBitInt (32768), 0);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSixteenBitInt (16385), -16383);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSixteenBitInt (1), -32767);
         REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSixteenBitInt (0), -32768);
-        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSixteenBitInt (std::numeric_limits<uint16_t>::min()), -32768);
+        REQUIRE_EQ (AudioSampleConverter<uint16_t>::sampleToSixteenBitInt ((std::numeric_limits<uint16_t>::min)()), -32768);
         
-        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSixteenBitInt (std::numeric_limits<uint32_t>::max()), 32767);
+        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSixteenBitInt ((std::numeric_limits<uint32_t>::max)()), 32767);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSixteenBitInt (65535), 32767);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSixteenBitInt (49151), 16383);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSixteenBitInt (32768), 0);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSixteenBitInt (16385), -16383);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSixteenBitInt (1), -32767);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSixteenBitInt (0), -32768);
-        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSixteenBitInt (std::numeric_limits<uint32_t>::min()), -32768);
+        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToSixteenBitInt ((std::numeric_limits<uint32_t>::min)()), -32768);
         
-        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSixteenBitInt (std::numeric_limits<uint64_t>::max()), 32767);
+        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSixteenBitInt ((std::numeric_limits<uint64_t>::max)()), 32767);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSixteenBitInt (65535), 32767);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSixteenBitInt (49151), 16383);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSixteenBitInt (32768), 0);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSixteenBitInt (16385), -16383);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSixteenBitInt (1), -32767);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSixteenBitInt (0), -32768);
-        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSixteenBitInt (std::numeric_limits<uint64_t>::min()), -32768);
+        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToSixteenBitInt ((std::numeric_limits<uint64_t>::min)()), -32768);
     }
     
     //=============================================================
     TEST_CASE ("16-bit Conversions::sampleToSixteenBitInt (signed int)")
     {
-        REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSixteenBitInt (std::numeric_limits<int16_t>::max()), 32767);
+        REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSixteenBitInt ((std::numeric_limits<int16_t>::max)()), 32767);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSixteenBitInt (32767), 32767);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSixteenBitInt (16383), 16383);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSixteenBitInt (0), 0);
@@ -510,7 +510,7 @@ TEST_SUITE ("SampleConversionTests::16-bit Conversions")
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSixteenBitInt (-32768), -32768);
         REQUIRE_EQ (AudioSampleConverter<int16_t>::sampleToSixteenBitInt (std::numeric_limits<int16_t>::lowest()), -32768);
         
-        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSixteenBitInt (std::numeric_limits<int32_t>::max()), 32767);
+        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSixteenBitInt ((std::numeric_limits<int32_t>::max)()), 32767);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSixteenBitInt (32767), 32767);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSixteenBitInt (16383), 16383);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSixteenBitInt (0), 0);
@@ -519,7 +519,7 @@ TEST_SUITE ("SampleConversionTests::16-bit Conversions")
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSixteenBitInt (-32768), -32768);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToSixteenBitInt (std::numeric_limits<int32_t>::lowest()), -32768);
         
-        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSixteenBitInt (std::numeric_limits<int64_t>::max()), 32767);
+        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSixteenBitInt ((std::numeric_limits<int64_t>::max)()), 32767);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSixteenBitInt (32767), 32767);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSixteenBitInt (16383), 16383);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToSixteenBitInt (0), 0);
@@ -606,45 +606,45 @@ TEST_SUITE ("SampleConversionTests::24-bit Conversions")
     //=============================================================
     TEST_CASE ("24-bit Conversions::sampleToTwentyFourBitInt (unsigned integers)")
     {
-        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToTwentyFourBitInt (std::numeric_limits<uint32_t>::max()), 8388607);
+        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToTwentyFourBitInt ((std::numeric_limits<uint32_t>::max)()), 8388607);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToTwentyFourBitInt (16777215), 8388607);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToTwentyFourBitInt (12582911), 4194303);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToTwentyFourBitInt (8388608), 0);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToTwentyFourBitInt (4194305), -4194303);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToTwentyFourBitInt (1), -8388607);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToTwentyFourBitInt (0), -8388608);
-        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToTwentyFourBitInt (std::numeric_limits<uint32_t>::min()), -8388608);
+        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToTwentyFourBitInt ((std::numeric_limits<uint32_t>::min)()), -8388608);
         
-        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToTwentyFourBitInt (std::numeric_limits<uint64_t>::max()), 8388607);
+        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToTwentyFourBitInt ((std::numeric_limits<uint64_t>::max)()), 8388607);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToTwentyFourBitInt (16777215), 8388607);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToTwentyFourBitInt (12582911), 4194303);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToTwentyFourBitInt (8388608), 0);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToTwentyFourBitInt (4194305), -4194303);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToTwentyFourBitInt (1), -8388607);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToTwentyFourBitInt (0), -8388608);
-        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToTwentyFourBitInt (std::numeric_limits<uint64_t>::min()), -8388608);
+        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToTwentyFourBitInt ((std::numeric_limits<uint64_t>::min)()), -8388608);
     }
     
     //=============================================================
     TEST_CASE ("24-bit Conversions::sampleToTwentyFourBitInt (signed integers)")
     {
-        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToTwentyFourBitInt (std::numeric_limits<int32_t>::max()), 8388607);
+        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToTwentyFourBitInt ((std::numeric_limits<int32_t>::max)()), 8388607);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToTwentyFourBitInt (8388607), 8388607);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToTwentyFourBitInt (4194303), 4194303);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToTwentyFourBitInt (0), 0);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToTwentyFourBitInt (-4194303), -4194303);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToTwentyFourBitInt (-8388607), -8388607);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToTwentyFourBitInt (-8388608), -8388608);
-        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToTwentyFourBitInt (std::numeric_limits<int32_t>::min()), -8388608);
+        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToTwentyFourBitInt ((std::numeric_limits<int32_t>::min)()), -8388608);
         
-        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToTwentyFourBitInt (std::numeric_limits<int64_t>::max()), 8388607);
+        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToTwentyFourBitInt ((std::numeric_limits<int64_t>::max)()), 8388607);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToTwentyFourBitInt (8388607), 8388607);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToTwentyFourBitInt (4194303), 4194303);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToTwentyFourBitInt (0), 0);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToTwentyFourBitInt (-4194303), -4194303);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToTwentyFourBitInt (-8388607), -8388607);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToTwentyFourBitInt (-8388608), -8388608);
-        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToTwentyFourBitInt (std::numeric_limits<int64_t>::min()), -8388608);
+        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToTwentyFourBitInt ((std::numeric_limits<int64_t>::min)()), -8388608);
     }
 }
 
@@ -708,7 +708,7 @@ TEST_SUITE ("SampleConversionTests::32-bit Conversions")
     //=============================================================
     TEST_CASE ("32-bit Conversions::sampleToThirtyTwoBitInt (float and double)")
     {
-        REQUIRE_EQ (AudioSampleConverter<float>::sampleToThirtyTwoBitInt (std::numeric_limits<float>::max()), 2147483647);
+        REQUIRE_EQ (AudioSampleConverter<float>::sampleToThirtyTwoBitInt ((std::numeric_limits<float>::max)()), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToThirtyTwoBitInt (1.f), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToThirtyTwoBitInt (0.5f), 1073741824);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToThirtyTwoBitInt (0.f), 0);
@@ -716,7 +716,7 @@ TEST_SUITE ("SampleConversionTests::32-bit Conversions")
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToThirtyTwoBitInt (-1.f), -2147483647);
         REQUIRE_EQ (AudioSampleConverter<float>::sampleToThirtyTwoBitInt (std::numeric_limits<float>::lowest()), -2147483647);
         
-        REQUIRE_EQ (AudioSampleConverter<double>::sampleToThirtyTwoBitInt (std::numeric_limits<double>::max()), 2147483647);
+        REQUIRE_EQ (AudioSampleConverter<double>::sampleToThirtyTwoBitInt ((std::numeric_limits<double>::max)()), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<double>::sampleToThirtyTwoBitInt (1.f), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<double>::sampleToThirtyTwoBitInt (0.5f), 1073741823);
         REQUIRE_EQ (AudioSampleConverter<double>::sampleToThirtyTwoBitInt (0.f), 0);
@@ -728,44 +728,44 @@ TEST_SUITE ("SampleConversionTests::32-bit Conversions")
     //=============================================================
     TEST_CASE ("32-bit Conversions::sampleToThirtyTwoBitInt (unsigned integers)")
     {
-        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToThirtyTwoBitInt (std::numeric_limits<uint32_t>::max()), 2147483647);
+        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToThirtyTwoBitInt ((std::numeric_limits<uint32_t>::max)()), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToThirtyTwoBitInt (4294967295), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToThirtyTwoBitInt (3221225472), 1073741824);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToThirtyTwoBitInt (2147483648), 0);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToThirtyTwoBitInt (1073741824), -1073741824);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToThirtyTwoBitInt (1), -2147483647);
         REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToThirtyTwoBitInt (0), -2147483648);
-        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToThirtyTwoBitInt (std::numeric_limits<uint32_t>::min()), -2147483648);
+        REQUIRE_EQ (AudioSampleConverter<uint32_t>::sampleToThirtyTwoBitInt ((std::numeric_limits<uint32_t>::min)()), -2147483648);
         
-        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToThirtyTwoBitInt (std::numeric_limits<uint64_t>::max()), 2147483647);
+        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToThirtyTwoBitInt ((std::numeric_limits<uint64_t>::max)()), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToThirtyTwoBitInt (4294967295), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToThirtyTwoBitInt (3221225472), 1073741824);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToThirtyTwoBitInt (2147483648), 0);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToThirtyTwoBitInt (1073741824), -1073741824);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToThirtyTwoBitInt (1), -2147483647);
         REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToThirtyTwoBitInt (0), -2147483648);
-        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToThirtyTwoBitInt (std::numeric_limits<uint64_t>::min()), -2147483648);
+        REQUIRE_EQ (AudioSampleConverter<uint64_t>::sampleToThirtyTwoBitInt ((std::numeric_limits<uint64_t>::min)()), -2147483648);
     }
     
     //=============================================================
     TEST_CASE ("32-bit Conversions::sampleToThirtyTwoBitInt (signed integers)")
     {
-        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToThirtyTwoBitInt (std::numeric_limits<int32_t>::max()), 2147483647);
+        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToThirtyTwoBitInt ((std::numeric_limits<int32_t>::max)()), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToThirtyTwoBitInt (2147483647), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToThirtyTwoBitInt (1073741824), 1073741824);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToThirtyTwoBitInt (0), 0);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToThirtyTwoBitInt (-1073741824), -1073741824);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToThirtyTwoBitInt (-2147483647), -2147483647);
         REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToThirtyTwoBitInt (-2147483648), -2147483648);
-        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToThirtyTwoBitInt (std::numeric_limits<int32_t>::min()), -2147483648);
+        REQUIRE_EQ (AudioSampleConverter<int32_t>::sampleToThirtyTwoBitInt ((std::numeric_limits<int32_t>::min)()), -2147483648);
         
-        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToThirtyTwoBitInt (std::numeric_limits<int64_t>::max()), 2147483647);
+        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToThirtyTwoBitInt ((std::numeric_limits<int64_t>::max)()), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToThirtyTwoBitInt (2147483647), 2147483647);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToThirtyTwoBitInt (1073741824), 1073741824);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToThirtyTwoBitInt (0), 0);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToThirtyTwoBitInt (-1073741824), -1073741824);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToThirtyTwoBitInt (-2147483647), -2147483647);
         REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToThirtyTwoBitInt (-2147483648LL), -2147483648LL);
-        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToThirtyTwoBitInt (std::numeric_limits<int64_t>::min()), -2147483648);
+        REQUIRE_EQ (AudioSampleConverter<int64_t>::sampleToThirtyTwoBitInt ((std::numeric_limits<int64_t>::min)()), -2147483648);
     }
 }

--- a/tests/doctest/doctest.h
+++ b/tests/doctest/doctest.h
@@ -3751,7 +3751,7 @@ String::size_type String::capacity() const {
 }
 
 String String::substr(size_type pos, size_type cnt) && {
-    cnt = std::min(cnt, size() - 1 - pos);
+    cnt = (std::min)(cnt, size() - 1 - pos);
     char* cptr = c_str();
     memmove(cptr, cptr + pos, cnt);
     setSize(cnt);
@@ -3759,7 +3759,7 @@ String String::substr(size_type pos, size_type cnt) && {
 }
 
 String String::substr(size_type pos, size_type cnt) const & {
-    cnt = std::min(cnt, size() - 1 - pos);
+    cnt = (std::min)(cnt, size() - 1 - pos);
     return String{ c_str() + pos, cnt };
 }
 
@@ -3774,7 +3774,7 @@ String::size_type String::find(char ch, size_type pos) const {
 
 String::size_type String::rfind(char ch, size_type pos) const {
     const char* begin = c_str();
-    const char* it = begin + std::min(pos, size() - 1);
+    const char* it = begin + (std::min)(pos, size() - 1);
     for (; it >= begin && *it != ch; it--);
     if (it >= begin) { return static_cast<size_type>(it - begin); }
     else { return npos; }
@@ -3983,7 +3983,7 @@ Approx& Approx::scale(double newScale) {
 bool operator==(double lhs, const Approx& rhs) {
     // Thanks to Richard Harris for his help refining this formula
     return std::fabs(lhs - rhs.m_value) <
-           rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));
+           rhs.m_epsilon * (rhs.m_scale + (std::max<double>)(std::fabs(lhs), std::fabs(rhs.m_value)));
 }
 bool operator==(const Approx& lhs, double rhs) { return operator==(rhs, lhs); }
 bool operator!=(double lhs, const Approx& rhs) { return !operator==(lhs, rhs); }
@@ -6246,9 +6246,9 @@ namespace {
             separator_to_stream();
             s << std::dec;
 
-            auto totwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
-            auto passwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
-            auto failwidth = int(std::ceil(log10((std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
+            auto totwidth = int(std::ceil(log10(((std::max)(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
+            auto passwidth = int(std::ceil(log10(((std::max)(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
+            auto failwidth = int(std::ceil(log10(((std::max)(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
             const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
             s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
               << p.numTestCasesPassingFilters << " | "


### PR DESCRIPTION
Removed the `#define NOMINMAX` and replaced all instances of these:
`std::min(x, y)` with `(std::min)(x, y)`
`std::max(x, y)` with `(std::max)(x, y)`
`std::numeric_limits<T>::max()` with `(std::numeric_limits<T>::max)()`