### PR TITLE
Remove redundant zeroing

### DIFF
--- a/AudioFile.h
+++ b/AudioFile.h
@@ -437,15 +437,9 @@ void AudioFile<T>::setAudioBufferSize (int numChannels, int numSamples)
 template <class T>
 void AudioFile<T>::setNumSamplesPerChannel (int numSamples)
 {
-    int originalSize = getNumSamplesPerChannel();
-    
     for (int i = 0; i < getNumChannels();i++)
     {
-        samples[i].resize (numSamples);
-        
-        // set any new samples to zero
-        if (numSamples > originalSize)
-            std::fill (samples[i].begin() + originalSize, samples[i].end(), (T)0.);
+        samples[i].resize (numSamples, static_cast<T>(0));
     }
 }
 
@@ -460,13 +454,9 @@ void AudioFile<T>::setNumChannels (int numChannels)
     
     // make sure any new channels are set to the right size
     // and filled with zeros
-    if (numChannels > originalNumChannels)
+    for (int i = originalNumChannels; i < numChannels; i++)
     {
-        for (int i = originalNumChannels; i < numChannels; i++)
-        {
-            samples[i].resize (originalNumSamplesPerChannel);
-            std::fill (samples[i].begin(), samples[i].end(), (T)0.);
-        }
+        samples[i].resize (originalNumSamplesPerChannel, static_cast<T>(0));
     }
 }
 


### PR DESCRIPTION
`std::vector::resize` already zeroes the new samples, so we don't need to use `std::fill`. See https://stackoverflow.com/a/73333009/10477326

However, we pass a second parameter to explicitly copy-init with zero
and to not default-init. Benchmarks showed the performance difference
between the two to be statistically insignificant, despite default-init
having memset.