### PR TITLE
bugfix: AudioFile<double> not properly saved to 32-bit (IEEE floating-point) WAV

### DIFF
--- a/AudioFile.h
+++ b/AudioFile.h
@@ -995,7 +995,16 @@ bool AudioFile<T>::encodeWaveFile (std::vector<uint8_t>& fileData)
                 int32_t sampleAsInt;
                 
                 if (audioFormat == WavAudioFormat::IEEEFloat)
-                    sampleAsInt = (int32_t) reinterpret_cast<int32_t&> (samples[channel][i]);
+                {
+                    if constexpr (std::is_same_v<T, float>)
+                        sampleAsInt = (int32_t) reinterpret_cast<int32_t&> (samples[channel][i]);
+                    else if constexpr (std::is_same_v<T, double>)
+                    {
+                        auto sampleAsFloat = (float) samples[channel][i];
+                        float& referenceToSample = sampleAsFloat;
+                        sampleAsInt = (int32_t) reinterpret_cast<int32_t&> (referenceToSample);
+                    }
+                }
                 else // assume PCM
                     sampleAsInt = AudioSampleConverter<T>::sampleToThirtyTwoBitInt (samples[channel][i]);
                 

--- a/AudioFile.h
+++ b/AudioFile.h
@@ -997,7 +997,9 @@ bool AudioFile<T>::encodeWaveFile (std::vector<uint8_t>& fileData)
                 if (audioFormat == WavAudioFormat::IEEEFloat)
                 {
                     if constexpr (std::is_same_v<T, float>)
+                    {
                         sampleAsInt = (int32_t) reinterpret_cast<int32_t&> (samples[channel][i]);
+                    }
                     else if constexpr (std::is_same_v<T, double>)
                     {
                         auto sampleAsFloat = (float) samples[channel][i];
@@ -1006,7 +1008,9 @@ bool AudioFile<T>::encodeWaveFile (std::vector<uint8_t>& fileData)
                     }
                 }
                 else // assume PCM
+                {
                     sampleAsInt = AudioSampleConverter<T>::sampleToThirtyTwoBitInt (samples[channel][i]);
+                }
                 
                 addInt32ToFileData (fileData, sampleAsInt, Endianness::LittleEndian);
             }

--- a/tests/FileWritingTests.cpp
+++ b/tests/FileWritingTests.cpp
@@ -85,10 +85,9 @@ void writeTestAudioFile (int numChannels, int sampleRate, int bitDepth, AudioFil
     REQUIRE (OK);
     
     //-----------------------------------------------------------------
-    // for some key bit depths and mono/stereo files, read in the audio file
-    // we just wrote and do a sample-by-sample comparison to confirm we are
-    // writing good files
-    if ((bitDepth == 8 || bitDepth == 16 || bitDepth == 24) &&  numChannels <= 2)
+    // read in the audio file we just wrote and do a sample-by-sample
+    // comparison to confirm we are writing good files
+    if (numChannels <= 2)
     {
         AudioFile<T> audioFileReader;
         audioFileReader.load (filePath);
@@ -136,8 +135,33 @@ TEST_SUITE ("Writing Tests")
                     for (auto& format : audioFormats)
                     {
                         auto fmt_str = format == AudioFileFormat::Wave ? "wav" : "aiff";
-                        std::cerr << sampleRate << "Hz " << bitDepth << "-bit " << channels << " " << fmt_str << " (floating point)" << std::endl;
+                        std::cerr << sampleRate << "Hz " << bitDepth << "-bit " << channels << " " << fmt_str << " (float)" << std::endl;
                         writeTestAudioFile<float> (channels, sampleRate, bitDepth, format);
+                    }
+                }
+            }
+        }
+    }
+    
+    //=============================================================
+    TEST_CASE ("WritingTest::WriteSineToneToManyFormats::DoublePrecision")
+    {
+        std::vector<int> sampleRates = {22050, 44100, 48000, 96000};
+        std::vector<int> bitDepths = {8, 16, 24, 32};
+        std::vector<int> numChannels = {1, 2, 8};
+        std::vector<AudioFileFormat> audioFormats = {AudioFileFormat::Wave, AudioFileFormat::Aiff};
+        
+        for (auto& sampleRate : sampleRates)
+        {
+            for (auto& bitDepth : bitDepths)
+            {
+                for (auto& channels : numChannels)
+                {
+                    for (auto& format : audioFormats)
+                    {
+                        auto fmt_str = format == AudioFileFormat::Wave ? "wav" : "aiff";
+                        std::cerr << sampleRate << "Hz " << bitDepth << "-bit " << channels << " " << fmt_str << " (double)" << std::endl;
+                        writeTestAudioFile<double> (channels, sampleRate, bitDepth, format);
                     }
                 }
             }


### PR DESCRIPTION
Fixes issue (#96) with saving `AudioFile<double>` to 32-bit WAV producing loud, scratchy noise.
